### PR TITLE
Reference stable rails 4.0 release to avoid bundler issues

### DIFF
--- a/actionpack-action_caching.gemspec
+++ b/actionpack-action_caching.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'actionpack', '>= 4.0.0.beta', '< 5.0'
+  gem.add_dependency 'actionpack', '>= 4.0.0', '< 5.0'
 
   gem.add_development_dependency 'mocha'
   gem.add_development_dependency 'activerecord', '>= 4.0.0.beta', '< 5'


### PR DESCRIPTION
Workaround a bundler issue: bundler/bundler#2583

Error message:

```
Bundler could not find compatible versions for gem "actionpack":
  In Gemfile:
    rails (= 4.0.0) ruby depends on
      actionpack (= 4.0.0) ruby

    actionpack-action_caching (~> 1.0.0) ruby depends on
      actionpack (4.0.1.rc4)
```
