### PR TITLE
Use defined Railtie rather than directly load the monkey-patch

### DIFF
--- a/lib/actionpack/action_caching.rb
+++ b/lib/actionpack/action_caching.rb
@@ -1,1 +1,1 @@
-require 'action_controller/action_caching'
+require 'actionpack/action_caching/railtie'


### PR DESCRIPTION
It's so strange that this gem has a well written Railtie but totally ignores it. Thus, requiring current version of this gem (usually via Bundler) immediately loads AC::Base and its hooks.
