### PR TITLE
Update README - use svg instead of png

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ Contributing
 Code Status
 -----------
 
-* [![Build Status](https://travis-ci.org/rails/actionpack-action_caching.png?branch=master)](https://travis-ci.org/rails/actionpack-action_caching)
-* [![Dependency Status](https://gemnasium.com/rails/actionpack-action_caching.png)](https://gemnasium.com/rails/actionpack-action_caching)
+* [![Build Status](https://travis-ci.org/rails/actionpack-action_caching.svg?branch=master)](https://travis-ci.org/rails/actionpack-action_caching)
+* [![Dependency Status](https://gemnasium.com/rails/actionpack-action_caching.svg)](https://gemnasium.com/rails/actionpack-action_caching)


### PR DESCRIPTION
Changed the png build badges to svg.
