### PR TITLE
Support symbols in :cache_path option

### DIFF
--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -154,7 +154,7 @@ module ActionController
         def around(controller)
           cache_layout = @cache_layout.respond_to?(:call) ? @cache_layout.call(controller) : @cache_layout
 
-          path_options = if @cache_path.is_a?(Proc)
+          path_options = if @cache_path.is_a?(Proc) || @cache_path.respond_to?(:to_proc)
             controller.instance_exec(controller, &@cache_path)
           elsif @cache_path.respond_to?(:call)
             @cache_path.call(controller)


### PR DESCRIPTION
This tiny commit allows to use symbols in the `:cache_path` option via
the standard behavior of `Symbol#to_proc`. The controller's instance
method pointed by the symbol should be in a `protected` scope.
