### PR TITLE
Return content_type from request.format

### DIFF
--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -176,7 +176,7 @@ module ActionController
           body = controller.render_to_string(text: body, layout: true) unless cache_layout
 
           controller.response_body = body
-          controller.content_type = Mime[cache_path.extension || :html]
+          controller.content_type = controller.request.format
         end
       end
 


### PR DESCRIPTION
When client make request with Accept header, action cache ignore this information and use `params[:format]` as content type.

I could not reproduce the error in the test environment, but I factored test rails app with problem reproduced. https://github.com/bolshakov/action-cache-format-test

Without action cache, all responses are JSON

```
> curl -s -I http://127.0.0.1:3000/without_cache.json  | grep "^Content-Type:"
Content-Type: application/json; charset=utf-8
> curl -s -I -H "Accept: application/json" http://127.0.0.1:3000/without_cache  | grep "^Content-Type:"
Content-Type: application/json; charset=utf-8
```

With action cache it ignores `Accept` header:

```
> curl -s -I http://127.0.0.1:3000/with_cache.json  | grep "^Content-Type:"
Content-Type: application/json; charset=utf-8
> curl -s -I -H "Accept: application/json" http://127.0.0.1:3000/with_cache  | grep "^Content-Type:"
Content-Type: text/html; charset=utf-8
```
