### PR TITLE
Upgrade to Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 before_install:
   - gem install bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: ruby
 before_install:
   - gem install bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.2.2
 gemfile:
   - Gemfile
   - gemfiles/Gemfile-edge
-  - gemfiles/Gemfile-4-0-stable
 matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile-edge

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rails'
+gem 'rails', github: 'rails/rails'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ authentication and other restrictions on whether someone is allowed
 to execute such action.
 
     class ListsController < ApplicationController
-      before_filter :authenticate, except: :public
+      before_action :authenticate, except: :public
 
       caches_page   :public
       caches_action :index, :show
@@ -72,7 +72,7 @@ interval (in seconds) to schedule expiration of the cached item.
 The following example depicts some of the points made above:
 
     class ListsController < ApplicationController
-      before_filter :authenticate, except: :public
+      before_action :authenticate, except: :public
 
       caches_page :public
 

--- a/actionpack-action_caching.gemspec
+++ b/actionpack-action_caching.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'actionpack-action_caching'
-  gem.version       = '1.1.0'
+  gem.version       = '2.0.0'
   gem.author        = 'David Heinemeier Hansson'
   gem.email         = 'david@loudthinking.com'
   gem.description   = 'Action caching for Action Pack (removed from core in Rails 4.0)'
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.license       = 'MIT'
 
-  gem.add_dependency 'actionpack', '>= 4.0.0', '< 5.0'
+  gem.add_dependency 'actionpack', '~> 5.x'
 
   gem.add_development_dependency 'mocha'
-  gem.add_development_dependency 'activerecord', '>= 4.0.0.beta', '< 5'
+  gem.add_development_dependency 'activerecord', '~> 5.x'
 end

--- a/actionpack-action_caching.gemspec
+++ b/actionpack-action_caching.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Action caching for Action Pack (removed from core in Rails 4.0)'
   gem.homepage      = 'https://github.com/rails/actionpack-action_caching'
 
+  gem.required_ruby_version = '>= 2.2.2'
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})

--- a/gemfiles/Gemfile-4-0-stable
+++ b/gemfiles/Gemfile-4-0-stable
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'rails', github: 'rails/rails', branch: '4-0-stable'

--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -10,7 +10,7 @@ module ActionController
     # to execute such action.
     #
     #   class ListsController < ApplicationController
-    #     before_filter :authenticate, except: :public
+    #     before_action :authenticate, except: :public
     #
     #     caches_page   :public
     #     caches_action :index, :show
@@ -66,7 +66,7 @@ module ActionController
     #
     #
     #   class ListsController < ApplicationController
-    #     before_filter :authenticate, except: :public
+    #     before_action :authenticate, except: :public
     #
     #     caches_page :public
     #
@@ -113,7 +113,7 @@ module ActionController
           filter_options = options.extract!(:if, :unless).merge(only: actions)
           cache_options  = options.extract!(:layout, :cache_path).merge(store_options: options)
 
-          around_filter ActionCacheFilter.new(cache_options), filter_options
+          around_action ActionCacheFilter.new(cache_options), filter_options
         end
       end
 

--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -173,7 +173,7 @@ module ActionController
             body = controller._save_fragment(cache_path.path, @store_options)
           end
 
-          body = controller.render_to_string(text: body, layout: true) unless cache_layout
+          body = controller.render_to_string(plain: body, layout: true) unless cache_layout
 
           controller.response_body = body
           controller.content_type = Mime[cache_path.extension || :html]

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -48,7 +48,7 @@ class ActionCachingTestController < CachingController
 
   def index
     @cache_this = MockTime.now.to_f.to_s
-    render text: @cache_this
+    render plain: @cache_this
   end
 
   def redirected
@@ -56,19 +56,19 @@ class ActionCachingTestController < CachingController
   end
 
   def forbidden
-    render text: 'Forbidden'
+    render plain: 'Forbidden'
     response.status = '403 Forbidden'
   end
 
   def with_layout
     @cache_this = MockTime.now.to_f.to_s
     @title = nil
-    render text: @cache_this, layout: true
+    render plain: @cache_this, layout: true
   end
 
   def with_format_and_http_param
     @cache_this = MockTime.now.to_f.to_s
-    render text: @cache_this
+    render plain: @cache_this
   end
 
   def with_symbol_format
@@ -81,7 +81,7 @@ class ActionCachingTestController < CachingController
   end
 
   def four_oh_four
-    render text: "404'd!", status: 404
+    render plain: "404'd!", status: 404
   end
 
   def simple_runtime_error
@@ -111,7 +111,7 @@ class ActionCachingTestController < CachingController
   end
 
   def streaming
-    render text: 'streaming', stream: true
+    render plain: 'streaming', stream: true
   end
 
   def invalid

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -97,17 +97,17 @@ class ActionCachingTestController < CachingController
 
   def expire
     expire_action controller: 'action_caching_test', action: 'index'
-    render nothing: true
+    head :ok
   end
 
   def expire_xml
     expire_action controller: 'action_caching_test', action: 'index', format: 'xml'
-    render nothing: true
+    head :ok
   end
 
   def expire_with_url_string
     expire_action url_for(controller: 'action_caching_test', action: 'index')
-    render nothing: true
+    head :ok
   end
 
   def streaming

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -39,7 +39,7 @@ class ActionCachingTestController < CachingController
   caches_action :with_format_and_http_param, cache_path: Proc.new { |c| { key: 'value' } }
   caches_action :with_symbol_format, cache_path: 'http://test.host/action_caching_test/with_symbol_format'
   caches_action :layout_false, layout: false
-  caches_action :with_layout_proc_param, layout: Proc.new { |c| c.params[:layout] }
+  caches_action :with_layout_proc_param, layout: Proc.new { |c| c.params[:layout] != "false" }
   caches_action :record_not_found, :four_oh_four, :simple_runtime_error
   caches_action :streaming
   caches_action :invalid

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -533,7 +533,7 @@ class ActionCacheTest < ActionController::TestCase
   private
 
     def content_to_cache
-      assigns(:cache_this)
+      @controller.instance_variable_get(:@cache_this)
     end
 
     def fragment_exist?(path)

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -239,13 +239,13 @@ class ActionCacheTest < ActionController::TestCase
   end
 
   def test_action_cache_with_layout_and_layout_cache_false_via_proc
-    get :with_layout_proc_param, layout: false
+    get :with_layout_proc_param, params: { layout: false }
     assert_response :success
     cached_time = content_to_cache
     assert_not_equal cached_time, @response.body
     assert fragment_exist?('hostname.com/action_caching_test/with_layout_proc_param')
 
-    get :with_layout_proc_param, layout: false
+    get :with_layout_proc_param, params: { layout: false }
     assert_response :success
     assert_not_equal cached_time, @response.body
     body = body_to_string(read_fragment('hostname.com/action_caching_test/with_layout_proc_param'))
@@ -253,13 +253,13 @@ class ActionCacheTest < ActionController::TestCase
   end
 
   def test_action_cache_with_layout_and_layout_cache_true_via_proc
-    get :with_layout_proc_param, layout: true
+    get :with_layout_proc_param, params: { layout: true }
     assert_response :success
     cached_time = content_to_cache
     assert_not_equal cached_time, @response.body
     assert fragment_exist?('hostname.com/action_caching_test/with_layout_proc_param')
 
-    get :with_layout_proc_param, layout: true
+    get :with_layout_proc_param, params: { layout: true }
     assert_response :success
     assert_not_equal cached_time, @response.body
     body = body_to_string(read_fragment('hostname.com/action_caching_test/with_layout_proc_param'))
@@ -312,7 +312,7 @@ class ActionCacheTest < ActionController::TestCase
     assert_response :success
     assert fragment_exist?('test.host/edit')
 
-    get :edit, id: 1
+    get :edit, params: { id: 1 }
     assert_response :success
     assert fragment_exist?('test.host/1;edit')
   end
@@ -322,7 +322,7 @@ class ActionCacheTest < ActionController::TestCase
     assert_response :success
     assert fragment_exist?('controller')
 
-    get :custom_cache_path, id: 1
+    get :custom_cache_path, params: { id: 1 }
     assert_response :success
     assert fragment_exist?('controller-1')
   end
@@ -440,8 +440,8 @@ class ActionCacheTest < ActionController::TestCase
 
   def test_correct_content_type_is_returned_for_cache_hit
     # run it twice to cache it the first time
-    get :index, id: 'content-type', format: 'xml'
-    get :index, id: 'content-type', format: 'xml'
+    get :index, params: { id: 'content-type' }, format: 'xml'
+    get :index, params: { id: 'content-type' }, format: 'xml'
     assert_response :success
     assert_equal 'application/xml', @response.content_type
   end
@@ -456,8 +456,8 @@ class ActionCacheTest < ActionController::TestCase
 
   def test_correct_content_type_is_returned_for_cache_hit_on_action_with_string_key_from_proc
     # run it twice to cache it the first time
-    get :edit, id: 1, format: 'xml'
-    get :edit, id: 1, format: 'xml'
+    get :edit, params: { id: 1 }, format: 'xml'
+    get :edit, params: { id: 1 }, format: 'xml'
     assert_response :success
     assert_equal 'application/xml', @response.content_type
   end
@@ -470,8 +470,8 @@ class ActionCacheTest < ActionController::TestCase
   end
 
   def test_file_extensions
-    get :index, id: 'kitten.jpg'
-    get :index, id: 'kitten.jpg'
+    get :index, params: { id: 'kitten.jpg' }
+    get :index, params: { id: 'kitten.jpg' }
 
     assert_response :success
   end

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -25,9 +25,9 @@ class ActionCachingTestController < CachingController
   end
 
   # Eliminate uninitialized ivar warning
-  before_filter { @title = nil }
+  before_action { @title = nil }
 
-  before_filter only: :with_symbol_format do
+  before_action only: :with_symbol_format do
     request.params[:format] = :json
   end
 


### PR DESCRIPTION
This bumps the gem to Rails 5. Because of Rails and Rack requirements we need to run on Ruby 2.2.0. Additionally changes required by Rails 5 will not work on older versions of Rails so to deal with that I've done what we did with other apps, bump to the next major version and will be making a 1-0-stable version of the branch for changes needed pre Rails 5.
- I've fixed all the deprecation warnings
- Set the Ruby version for travis to 2.2.2
- Set travis to run on the new infra
- Fixed a failing test from changes made to parameters.
