### PR TITLE
fix caches_action with layout false

### DIFF
--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -124,7 +124,8 @@ module ActionController
         end
 
         if caching_allowed?
-          write_fragment(name, content, options)
+          result = write_fragment(name, content, options)
+          result.respond_to?(:html_safe) ? result.html_safe : result
         else
           content
         end


### PR DESCRIPTION
If I set `caches_action :home, layout: false` and the cache is not created, my action return a string that is not safe!
I added html_safe method, which is also used in http://apidock.com/rails/ActionController/Caching/Fragments/read_fragment