### PR TITLE
Fix #43 html escaping when layout is false

### DIFF
--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -177,7 +177,7 @@ module ActionController
           end
         else
           def render_to_string(controller, body)
-            controller.render_to_string(html: body, layout: true)
+            controller.render_to_string(html: body.html_safe, layout: true)
           end
         end
 

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -52,7 +52,7 @@ class ActionCachingTestController < CachingController
   layout "talk_from_action"
 
   def index
-    @cache_this = MockTime.now.to_f.to_s
+    @cache_this = CacheContent.to_s
     render plain: @cache_this
   end
 
@@ -66,17 +66,17 @@ class ActionCachingTestController < CachingController
   end
 
   def with_layout
-    @cache_this = MockTime.now.to_f.to_s
+    @cache_this = CacheContent.to_s
     render html: @cache_this, layout: true
   end
 
   def with_format_and_http_param
-    @cache_this = MockTime.now.to_f.to_s
+    @cache_this = CacheContent.to_s
     render plain: @cache_this
   end
 
   def with_symbol_format
-    @cache_this = MockTime.now.to_f.to_s
+    @cache_this = CacheContent.to_s
     render json: { timestamp: @cache_this }
   end
 
@@ -126,7 +126,7 @@ class ActionCachingTestController < CachingController
   end
 
   def invalid
-    @cache_this = MockTime.now.to_f.to_s
+    @cache_this = CacheContent.to_s
 
     respond_to do |format|
       format.json { render json: @cache_this }
@@ -134,7 +134,7 @@ class ActionCachingTestController < CachingController
   end
 
   def accept
-    @cache_this = MockTime.now.to_f.to_s
+    @cache_this = CacheContent.to_s
 
     respond_to do |format|
       format.html { render html: @cache_this }
@@ -174,10 +174,11 @@ class ActionCachingTestController < CachingController
     end
 end
 
-class MockTime < Time
-  # Let Time spicy to assure that Time.now != Time.now
-  def to_f
-    super + rand
+class CacheContent
+  def self.to_s
+    # Let Time spicy to assure that Time.now != Time.now
+    time = Time.now.to_f + rand
+    (time.to_s + "<div />").html_safe
   end
 end
 
@@ -391,7 +392,7 @@ class ActionCacheTest < ActionController::TestCase
       get "/action_caching_test", to: "action_caching_test#index"
     end
 
-    MockTime.expects(:now).returns(12345).once
+    CacheContent.expects(:to_s).returns('12345.0').once
     @controller.expects(:read_fragment).with("hostname.com/action_caching_test", expires_in: 1.hour).once
     @controller.expects(:write_fragment).with("hostname.com/action_caching_test", "12345.0", expires_in: 1.hour).once
     get :index


### PR DESCRIPTION
Fixes #43. Same as PR #42 but fixes the cause of the problem. 

From [rails docs](http://guides.rubyonrails.org/layouts_and_rendering.html#using-render):
> When using html: option, HTML entities will be escaped if the string is not marked as HTML safe by using html_safe method.