### PR TITLE
Allow cache to be re-generated on-demand without first deleting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ indicates a HTML request the fragment is stored without the
 extension but if an explicit `"html"` is passed in `:format` then
 that _is_ used for storing the fragment.
 
+If you would like your cache to be regenerated on-demand without
+first clearing it, you can append a `cache=force` param to your
+URL (ex: `http://mysite.com/videos/list?cache=force`).
+
 Contributing
 ------------
 

--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -156,7 +156,9 @@ module ActionController
           path_options = expand_option(controller, @cache_path)
           cache_path = ActionCachePath.new(controller, path_options || {})
 
-          body = controller.read_fragment(cache_path.path, @store_options)
+          unless controller.params[:cache] == 'force'
+            body = controller.read_fragment(cache_path.path, @store_options)
+          end
 
           unless body
             controller.action_has_layout = false unless cache_layout

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -48,6 +48,7 @@ class ActionCachingTestController < CachingController
   caches_action :streaming
   caches_action :invalid
   caches_action :accept
+  caches_action :regenerate
 
   layout "talk_from_action"
 
@@ -140,6 +141,11 @@ class ActionCachingTestController < CachingController
       format.html { render html: @cache_this }
       format.json { render json: @cache_this }
     end
+  end
+
+  def regenerate
+    @cache_this = MockTime.now.to_f.to_s
+    render plain: @cache_this
   end
 
   def expire_accept
@@ -837,6 +843,22 @@ class ActionCacheTest < ActionController::TestCase
     assert_response :success
     assert_equal "<title>Request 2</title>\n#{cached_time}", @response.body
     assert_equal cached_time, read_fragment("hostname.com/action_caching_test/with_layout_proc_param_no_args")
+  end
+
+  def test_regenerate_without_expiring
+    draw do
+      get "/action_caching_test/regenerate", to: "action_caching_test#regenerate"
+    end
+
+    get :regenerate
+    cached_time = content_to_cache
+    assert_equal cached_time, @response.body
+    assert fragment_exist?("hostname.com/action_caching_test/regenerate")
+
+    get :regenerate, params: { cache: 'force' }
+    updated_cached_time = content_to_cache
+    assert_equal updated_cached_time, @response.body
+    assert_equal read_fragment("hostname.com/action_caching_test/regenerate"), updated_cached_time
   end
 
   private


### PR DESCRIPTION
I'm not sure if this addition would be useful to anyone else, but it's something that my current employer could definitely use.

We have an endpoint that is very expensive to generate when there is no cache. When we clear the cache, if the app is under heavy load, we get stressed db and app servers.

I'm open to any feedback about changes/additions you'd like to see with this feature.