### PR TITLE
[ci-skip] Remove Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,3 @@ Code Status
 -----------
 
 * [![Build Status](https://travis-ci.org/rails/actionpack-action_caching.svg?branch=master)](https://travis-ci.org/rails/actionpack-action_caching)
-* [![Dependency Status](https://gemnasium.com/rails/actionpack-action_caching.svg)](https://gemnasium.com/rails/actionpack-action_caching)


### PR DESCRIPTION
Since Gemnasium was acquired by Gitlab it doesn't work with GitHub by default anymore.
See https://docs.gitlab.com/ee/user/project/import/gemnasium.html