### PR TITLE
Allow `actionpack` 6

### DIFF
--- a/actionpack-action_caching.gemspec
+++ b/actionpack-action_caching.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "actionpack", ">= 4.0.0"
 
   gem.add_development_dependency "mocha"
-  gem.add_development_dependency "activerecord", ">= 4.0.0", "< 7"
+  gem.add_development_dependency "activerecord", ">= 4.0.0"
 end

--- a/actionpack-action_caching.gemspec
+++ b/actionpack-action_caching.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = "MIT"
 
-  gem.add_dependency "actionpack", ">= 4.0.0", "< 7"
+  gem.add_dependency "actionpack", ">= 4.0.0"
 
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "activerecord", ">= 4.0.0", "< 7"

--- a/actionpack-action_caching.gemspec
+++ b/actionpack-action_caching.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = "MIT"
 
-  gem.add_dependency "actionpack", ">= 4.0.0", "< 6"
+  gem.add_dependency "actionpack", ">= 4.0.0", "< 7"
 
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "activerecord", ">= 4.0.0", "< 6"

--- a/actionpack-action_caching.gemspec
+++ b/actionpack-action_caching.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "actionpack", ">= 4.0.0", "< 7"
 
   gem.add_development_dependency "mocha"
-  gem.add_development_dependency "activerecord", ">= 4.0.0", "< 6"
+  gem.add_development_dependency "activerecord", ">= 4.0.0", "< 7"
 end


### PR DESCRIPTION
Updates the gemspec to allow using `actionpack` with Rails 6 for
testing.