### PR TITLE
Ensure rendered html content gets allways marked as html_safe

### DIFF
--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -165,7 +165,7 @@ module ActionController
             body = controller._save_fragment(cache_path.path, @store_options)
           end
 
-          body = render_to_string(controller, body) unless cache_layout
+          body = render_to_string(controller, body.respond_to?(:html_safe) ? body.html_safe : body) unless cache_layout
 
           controller.response_body = body
           controller.content_type = Mime[cache_path.extension || :html]


### PR DESCRIPTION
Fixing https://github.com/rails/actionpack-action_caching/issues/64

So the problem is that read_fragment calls `html_safe` on the content string but save_fragment doesnt do that. So on the first call the content string gets piped to the renderer as unsafe and then it gets falsely escaped.
