### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/actionpack-action_caching.gemspec
+++ b/actionpack-action_caching.gemspec
@@ -7,6 +7,13 @@ Gem::Specification.new do |gem|
   gem.summary       = "Action caching for Action Pack (removed from core in Rails 4.0)"
   gem.homepage      = "https://github.com/rails/actionpack-action_caching"
 
+  gem.metadata = {
+    "bug_tracker_uri"   => "https://github.com/rails/actionpack-action_caching/issues",
+    "changelog_uri"     => "https://github.com/rails/actionpack-action_caching/blob/v#{gem.version}/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/actionpack-action_caching/#{gem.version}",
+    "source_code_uri"   => "https://github.com/rails/actionpack-action_caching/tree/v#{gem.version}",
+  }
+
   gem.required_ruby_version = ">= 1.9.3"
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/actionpack-action_caching), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.