### PR TITLE
Update CI matrix and make the gem Rails 6.1 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
+  - 2.7.1
 
 gemfile:
   - Gemfile
@@ -99,6 +100,17 @@ matrix:
       gemfile: gemfiles/Gemfile-5-0-stable
     - rvm: 2.6.3
       gemfile: gemfiles/Gemfile-5-1-stable
+    - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-4-0-stable
+    - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-4-1-stable
+    - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-4-2-stable
+    - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-5-0-stable
+    - rvm: 2.7.1
+      gemfile: gemfiles/Gemfile-5-1-stable
+
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ rvm:
   - 2.1.10
   - 2.2.10
   - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
-  - 2.7.1
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.2
 
 gemfile:
   - Gemfile
@@ -28,6 +28,7 @@ gemfile:
   - gemfiles/Gemfile-5-1-stable
   - gemfiles/Gemfile-5-2-stable
   - gemfiles/Gemfile-6-0-stable
+  - gemfiles/Gemfile-6-1-stable
   - gemfiles/Gemfile-edge
 
 matrix:
@@ -40,6 +41,12 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.1.10
       gemfile: Gemfile
+    - rvm: 2.2.10
+      gemfile: Gemfile
+    - rvm: 2.3.8
+      gemfile: Gemfile
+    - rvm: 2.4.10
+      gemfile: Gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile-5-0-stable
     - rvm: 1.9.3
@@ -48,6 +55,8 @@ matrix:
       gemfile: gemfiles/Gemfile-5-2-stable
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile-6-0-stable
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile-6-1-stable
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile-5-0-stable
     - rvm: 2.0.0
@@ -56,6 +65,8 @@ matrix:
       gemfile: gemfiles/Gemfile-5-2-stable
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile-6-0-stable
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile-6-1-stable
     - rvm: 2.1.10
       gemfile: gemfiles/Gemfile-5-0-stable
     - rvm: 2.1.10
@@ -68,8 +79,16 @@ matrix:
       gemfile: gemfiles/Gemfile-6-0-stable
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-6-0-stable
-    - rvm: 2.4.6
+    - rvm: 2.4.10
       gemfile: gemfiles/Gemfile-6-0-stable
+    - rvm: 2.1.10
+      gemfile: gemfiles/Gemfile-6-1-stable
+    - rvm: 2.2.10
+      gemfile: gemfiles/Gemfile-6-1-stable
+    - rvm: 2.3.8
+      gemfile: gemfiles/Gemfile-6-1-stable
+    - rvm: 2.4.10
+      gemfile: gemfiles/Gemfile-6-1-stable
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile-edge
     - rvm: 2.0.0
@@ -80,35 +99,35 @@ matrix:
       gemfile: gemfiles/Gemfile-edge
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-edge
-    - rvm: 2.4.6
+    - rvm: 2.4.10
       gemfile: gemfiles/Gemfile-edge
-    - rvm: 2.4.6
+    - rvm: 2.4.10
       gemfile: gemfiles/Gemfile-4-0-stable
-    - rvm: 2.4.6
+    - rvm: 2.4.10
       gemfile: gemfiles/Gemfile-4-1-stable
-    - rvm: 2.5.5
+    - rvm: 2.5.8
       gemfile: gemfiles/Gemfile-4-0-stable
-    - rvm: 2.5.5
+    - rvm: 2.5.8
       gemfile: gemfiles/Gemfile-4-1-stable
-    - rvm: 2.6.3
+    - rvm: 2.6.6
       gemfile: gemfiles/Gemfile-4-0-stable
-    - rvm: 2.6.3
+    - rvm: 2.6.6
       gemfile: gemfiles/Gemfile-4-1-stable
-    - rvm: 2.6.3
+    - rvm: 2.6.6
       gemfile: gemfiles/Gemfile-4-2-stable
-    - rvm: 2.6.3
+    - rvm: 2.6.6
       gemfile: gemfiles/Gemfile-5-0-stable
-    - rvm: 2.6.3
+    - rvm: 2.6.6
       gemfile: gemfiles/Gemfile-5-1-stable
-    - rvm: 2.7.1
+    - rvm: 2.7.2
       gemfile: gemfiles/Gemfile-4-0-stable
-    - rvm: 2.7.1
+    - rvm: 2.7.2
       gemfile: gemfiles/Gemfile-4-1-stable
-    - rvm: 2.7.1
+    - rvm: 2.7.2
       gemfile: gemfiles/Gemfile-4-2-stable
-    - rvm: 2.7.1
+    - rvm: 2.7.2
       gemfile: gemfiles/Gemfile-5-0-stable
-    - rvm: 2.7.1
+    - rvm: 2.7.2
       gemfile: gemfiles/Gemfile-5-1-stable
 
 

--- a/gemfiles/Gemfile-6-1-stable
+++ b/gemfiles/Gemfile-6-1-stable
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rails", github: "rails/rails", branch: "6-1-stable"

--- a/lib/action_controller/action_caching.rb
+++ b/lib/action_controller/action_caching.rb
@@ -2,6 +2,8 @@ require "action_controller/caching/actions"
 
 module ActionController
   module Caching
+    extend ActiveSupport::Autoload
+
     eager_autoload do
       autoload :Actions
     end

--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -228,7 +228,7 @@ module ActionController
 
       private
         def normalize!(path)
-          ext = URI.parser.escape(extension.to_s) if extension
+          ext = URI::DEFAULT_PARSER.escape(extension.to_s) if extension
           path << "index" if path[-1] == ?/
           path << ".#{ext}" if extension && !path.split("?", 2).first.ends_with?(".#{ext}")
           URI::DEFAULT_PARSER.unescape(path)

--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -230,7 +230,7 @@ module ActionController
         def normalize!(path)
           ext = URI::DEFAULT_PARSER.escape(extension.to_s) if extension
           path << "index" if path[-1] == ?/
-          path << ".#{ext}" if extension && !path.split("?", 2).first.ends_with?(".#{ext}")
+          path << ".#{ext}" if extension && !path.split("?", 2).first.end_with?(".#{ext}")
           URI::DEFAULT_PARSER.unescape(path)
         end
       end

--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -231,7 +231,7 @@ module ActionController
           ext = URI.parser.escape(extension.to_s) if extension
           path << "index" if path[-1] == ?/
           path << ".#{ext}" if extension && !path.split("?", 2).first.ends_with?(".#{ext}")
-          URI.parser.unescape(path)
+          URI::DEFAULT_PARSER.unescape(path)
         end
       end
     end


### PR DESCRIPTION
This PR is a cumulative changes to get CI build green and working on Rails 6.1. It include changes from these PRs:

- [Fix for rails 6.1](https://github.com/rails/actionpack-action_caching/pull/75)
- [Travis update ruby 2.7.1](https://github.com/rails/actionpack-action_caching/pull/72)

Original commits from those PRs are cherry-picked in to maintain original authors' credit, and I build on top of their work again in the subsequent commits.

In details, this PR

- Update Travis build matrix:
    - Add `6-1-stable` branch to the build matrix.
    - Add Ruby 2.7.2 to the build matrix.
    - Update previous version of Rubies to the latest patch version.
- Makes `ActionController::Caching` extends `ActiveSupport::Autoload`
- Switch the usage of `URI.parser` to `URI::DEFAULT_PARSER`
- Use `String#end_with?` instead of `String#ends_with?`

I've ran this branch on my own fork and [it's green on all supported Ruby/Rails versions](https://travis-ci.com/github/sikachu/actionpack-action_caching/builds/210483721).

This PR closes #72, closes #74, closes #75.