### PR TITLE
Add support for `ActionController::API` controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add support for `ActionController::API` controllers
+
+    *fatkodima*
+
+
 ## 1.2.2 (May 10, 2021)
 
 *   Add support for Rails 6.1

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ indicates a HTML request the fragment is stored without the
 extension but if an explicit `"html"` is passed in `:format` then
 that _is_ used for storing the fragment.
 
+`ActionController::API` controllers
+-----
+
+You need to manually include the `ActionController::Caching` module
+and configure it.
+
+```ruby
+class ApplicationController < ActionController::API
+  include ActionController::Caching
+
+  # enable caching
+  self.perform_caching = true
+
+  # configure the cache store (or just use `self.cache_store = Rails.cache`)
+  self.cache_store = :redis_cache_store
+end
+
+class ListsController < ApplicationController
+  caches_action :index, :show
+end
+```
+
 Contributing
 ------------
 

--- a/lib/action_controller/caching/actions.rb
+++ b/lib/action_controller/caching/actions.rb
@@ -159,9 +159,13 @@ module ActionController
           body = controller.read_fragment(cache_path.path, @store_options)
 
           unless body
-            controller.action_has_layout = false unless cache_layout
-            yield
-            controller.action_has_layout = true
+            if controller.respond_to?(:action_has_layout=)
+              controller.action_has_layout = false unless cache_layout
+              yield
+              controller.action_has_layout = true
+            else
+              yield
+            end
             body = controller._save_fragment(cache_path.path, @store_options)
           end
 


### PR DESCRIPTION
Closes #79. 
Closes #46.

Fixed `action_has_layout` non-existent method for api controllers and added the docs to readme about how to configure caching for api controllers.

cc @rafaelfranca 