### PR TITLE
Fix broken test case

### DIFF
--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -813,7 +813,6 @@ class ActionCacheTest < ActionController::TestCase
     assert fragment_exist?("hostname.com/action_caching_test/accept.html")
 
     get :accept, format: "html"
-    cached_time = content_to_cache
     assert_cached cached_time
 
     get :expire_accept, format: "html"
@@ -866,6 +865,7 @@ class ActionCacheTest < ActionController::TestCase
 
     def assert_cached(cache_time, media_type = "text/html")
       assert_response :success
+      assert_not_nil cache_time
       assert_equal cache_time, @response.body
 
       if @response.respond_to?(:media_type)


### PR DESCRIPTION
```
$ rake test
Run options: --seed 64620

# Running:

.........................F

Failure:
ActionCacheTest#test_explicit_html_format_is_used_for_fragment_path [/Users/fatkodima/Desktop/oss/actionpack-action_caching/test/caching_test.rb:817]:
Expected: nil
  Actual: "1662930799.070181<div />"


rails test Users/fatkodima/Desktop/oss/actionpack-action_caching/test/caching_test.rb:803

............

Finished in 0.509232s, 74.6222 runs/s, 349.5460 assertions/s.
38 runs, 178 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)
```

This test case had a bug and correctly started to fail after the https://github.com/rails/rails/pull/43735.

So before that Rails' PR:  
1. `@cache_this` instance variable variable was not reset after the first `get` in that test case
2. after the second `get`, the action was not executed and `content_to_cache` returned a stale `@cache_this` and compared it to the cached response from the action

After the Rails' PR:
1. `@cache_this` is reset to `nil` before the second `get`
2. `content_to_cache` return `nil` from the step 1, but cached response is not equal to `nil`, so here is the test failure

Having `cached_time = content_to_cache` line is incorrect and this bug was unnoticed before that PR, so we need to remove it.