### PR TITLE
Clarifying example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Different representations of the same resource, e.g.
 are treated like separate requests and so are cached separately.
 Keep in mind when expiring an action cache that
 `action: "lists"` is not the same as
-`action: "list", format: :xml`.
+`action: "lists", format: :xml`.
 
 You can modify the default action cache path by passing a
 `:cache_path` option. This will be passed directly to


### PR DESCRIPTION
Clarify the example, to make the point clearer that its about the format (and not a different action ...). This has also been done in the code documentation a couple of years ago: https://github.com/rails/actionpack-action_caching/commit/1ad693a3a6ef9f959a595585851b56a32df36215 .